### PR TITLE
Prepare the suppression of bridges

### DIFF
--- a/Component/BusinessComponentRegistry.php
+++ b/Component/BusinessComponentRegistry.php
@@ -31,13 +31,20 @@ class BusinessComponentRegistry
         if ($application == null) {
             $application = $this->appFinder->findFromUrl();
 
-            if (is_null($application)) throw new OutOfBoundsException(sprintf('business component for %s application not found', $application));
+            if (is_null($application)) {
+                throw new OutOfBoundsException(
+                    sprintf(
+                        'business component for %s application not found',
+                        $application
+                    )
+                );
+            }
 
             $application = $application->getCanonicalName();
         }
 
         if (array_key_exists($application, $this->businessComponents)) {
-           return $this->businessComponents[$application];
+            return $this->businessComponents[$application];
         }
 
         throw new OutOfBoundsException(sprintf('business component for %s application not found', $application));

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,36 +1,35 @@
-parameters:
-    canal_tp_sam_ecore_routing_loader.class: CanalTP\SamEcoreApplicationManagerBundle\Routing\ApplicationRoutingLoader
-    canal_tp_sam_ecore_route_prefix: 'business'
-    canal_tp_sam.perimeter.form.listener.class: CanalTP\SamEcoreApplicationManagerBundle\Form\EventListener\PerimeterSubscriber
-    canal_tp_sam.application.finder: CanalTP\SamEcoreApplicationManagerBundle\Services\ApplicationFinder
-    canal_tp_sam.application.entity: CanalTP\SamCoreBundle\Entity\Application
-    sam.event.check_access.class: CanalTP\SamEcoreApplicationManagerBundle\Event\CheckAccess
-
 services:
     canal_tp_sam_ecore_routing_loader:
-        class: %canal_tp_sam_ecore_routing_loader.class%
+        class: CanalTP\SamEcoreApplicationManagerBundle\Routing\ApplicationRoutingLoader
         arguments:
             - '@canal_tp_sam.application.finder'
-            - '%canal_tp_sam_ecore_route_prefix%'
+            - 'business'
         tags:
             - { name: routing.loader }
 
     sam.event.check_access:
-        class: %sam.event.check_access.class%
+        class: CanalTP\SamEcoreApplicationManagerBundle\Event\CheckAccess
         arguments:
             - '@service_container'
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
     canal_tp_sam.perimeter.form.listener:
-        class: %canal_tp_sam.perimeter.form.listener.class%
+        class: CanalTP\SamEcoreApplicationManagerBundle\Form\EventListener\PerimeterSubscriber
         arguments:
-            - @sam.business_component
-            - @security.context
-            - @fos_user.user_manager
+            - '@sam.business_component'
+            - '@security.context'
+            - '@fos_user.user_manager'
 
     canal_tp_sam.application.finder:
-        class: %canal_tp_sam.application.finder%
+        class: CanalTP\SamEcoreApplicationManagerBundle\Services\ApplicationFinder
         arguments:
-            - @service_container
-            - %canal_tp_sam.application.entity%
+            - '@service_container'
+            - CanalTP\SamCoreBundle\Entity\Application
+
+    sam.business_component:
+        class: CanalTP\SamEcoreApplicationManagerBundle\Component\BusinessComponentRegistry
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@session'
+            - '@canal_tp_sam.application.finder'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,6 @@ services:
         class: CanalTP\SamEcoreApplicationManagerBundle\Routing\ApplicationRoutingLoader
         arguments:
             - '@canal_tp_sam.application.finder'
-            - 'business'
         tags:
             - { name: routing.loader }
 


### PR DESCRIPTION
# Description

To be able to make "**Sam applications**" work, we need to create "**Bridge bundles**" (e.g.: [MttBridgeBundle](https://github.com/CanalTP/MttBridgeBundle))

These **bridges are not very useful and increase the maintenance.
This PR prepares the suppression of bridges and insure backward compatibility.

So we can start removing bridges (with some actions that will be made in another PRs) and Sam Applications can work both with or without their bridge.

- Added an interface SamApplication to detect that a bundle is a Sam Application
- Added **BusinessComponents** in a registry by tag

## Pull Request type

Enhancement.

## How to test

Everything must work like before mostly routing of sam applications

Run the tests for each sam applications.

run `app/console sam:database:reset`