### PR TITLE
fixed license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Sam e-core application bundle",
     "keywords": ["sam", "application", "manager"],
     "homepage": "https://github.com/CanalTP/SamEcoreApplicationManagerBundle",
-    "license": "AGPLv3",
+    "license": "AGPL-3.0-only",
     "authors": [
         {
             "name": "Rémy Abi-Khalil",


### PR DESCRIPTION
Fixed error on packagist
```
Importing branch master (dev-master)
Skipped branch master, Invalid package information: 
License "AGPLv3" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```